### PR TITLE
TagIt: Use non-modal stack for getting started screen navigation 

### DIFF
--- a/TagIt/tagit/tagit/Models/GettingStartedInformation.cs
+++ b/TagIt/tagit/tagit/Models/GettingStartedInformation.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using System.Windows.Input;
 using tagit.Common;
+using Xamarin.Forms;
 
 namespace tagit.Models
 {
@@ -8,7 +9,14 @@ namespace tagit.Models
     {
         public GettingStartedInformation()
         {
-            GetStartedCommand = new RelayCommand(async () => { await GetStartedAsync(); });
+            if (Device.RuntimePlatform == Device.iOS)
+            {
+                GetStartedCommand = new RelayCommand(async () => { await App.NavigationService.PopAsync(); });
+            }
+            else
+            { 
+                GetStartedCommand = new RelayCommand(async () => { await App.NavigationService.PopModalAsync(); }); 
+            }
         }
 
         private string _image;
@@ -18,7 +26,7 @@ namespace tagit.Models
         private string _subtitle;
 
         private string _title;
-        
+
         public ICommand GetStartedCommand { get; }
 
         public string Title
@@ -43,11 +51,6 @@ namespace tagit.Models
         {
             get => _isFinalItem;
             set => SetProperty(ref _isFinalItem, value);
-        }
-
-        private async Task GetStartedAsync()
-        {
-            await App.NavigationService.PopModalAsync();
         }
     }
 }

--- a/TagIt/tagit/tagit/ViewModels/HomeViewModel.cs
+++ b/TagIt/tagit/tagit/ViewModels/HomeViewModel.cs
@@ -26,7 +26,7 @@ namespace tagit.ViewModels
             MenuSelectedCommand = new RelayCommand(MenuSelected);
             SearchSelectedCommand = new RelayCommand(SearchSelected);
         }
- 
+
         public RadSideDrawer Drawer { get; set; }
 
         public ICommand NavigateFromMenuCommand { get; }
@@ -38,7 +38,7 @@ namespace tagit.ViewModels
         private ObservableCollection<NavigationItem> _navigationItems;
 
         private string _pageTitle;
-        
+
         public string PageTitle
         {
             get => _pageTitle;
@@ -100,10 +100,10 @@ namespace tagit.ViewModels
                 else if (selectedPage != null)
                     App.NavigationService.NavigateToPage(this, selectedPage.PageType);
 
-               
+
             }
         }
-        
+
         internal void InitializeNavigation()
         {
             PageTitle = (App.ViewModel != null && App.ViewModel.Settings.IsFirstRun) ? "" : AppResources.WelcomeTitle;
@@ -151,9 +151,16 @@ namespace tagit.ViewModels
 
         internal async void ShowFirstRun()
         {
-            //Show the Getting Started view if it's
+            //Show the Getting Started view if it's 
             //the first time a user has opened the app           
-            await App.NavigationService.PushModalAsync(new GettingStartedPage());
+            if (Device.RuntimePlatform == Device.iOS)
+            {
+                await App.NavigationService.PushAsync(new GettingStartedPage());
+            }
+            else
+            {
+                await App.NavigationService.PushModalAsync(new GettingStartedPage());
+            }
         }
 
         internal void EnableMainMenu(IList<Xamarin.Forms.ToolbarItem> toolbarItems)


### PR DESCRIPTION
TagIt: Use non-modal stack for getting started screen navigation because of issues with swipe gesture in modal stack on iOS 13.