### PR TITLE
Change the namespace of the Toolbar from the old support library to a…

### DIFF
--- a/ToDo/TodoApp/TodoApp.Android/Resources/layout/Toolbar.axml
+++ b/ToDo/TodoApp/TodoApp.Android/Resources/layout/Toolbar.axml
@@ -1,4 +1,4 @@
-<android.support.v7.widget.Toolbar
+<androidx.appcompat.widget.Toolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"


### PR DESCRIPTION
…ndroidx in order to prevent and exception to be thrown when the application starts.