### PR TITLE
Add Xamarin.Essentials reference to replace obsolete API.

### DIFF
--- a/ERP/app/ErpApp/ErpApp.Android/ErpApp.Android.csproj
+++ b/ERP/app/ErpApp/ErpApp.Android/ErpApp.Android.csproj
@@ -115,6 +115,9 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.6.1</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Essentials">
+      <Version>1.5.3.2</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading">
       <Version>2.4.11.982</Version>
     </PackageReference>

--- a/ERP/app/ErpApp/ErpApp.Android/MainActivity.cs
+++ b/ERP/app/ErpApp/ErpApp.Android/MainActivity.cs
@@ -17,6 +17,14 @@ namespace ErpApp.Droid
             ToolbarResource = Resource.Layout.Toolbar;
 
             base.OnCreate(bundle);
+            Xamarin.Essentials.Platform.Init(this, bundle);
+        }
+
+        public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Android.Content.PM.Permission[] grantResults)
+        {
+            Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+
+            base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
 

--- a/ERP/app/ErpApp/ErpApp.UWP/ErpApp.UWP.csproj
+++ b/ERP/app/ErpApp/ErpApp.UWP/ErpApp.UWP.csproj
@@ -208,6 +208,9 @@
     <PackageReference Include="SkiaSharp.Views.Forms">
       <Version>1.68.0</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Essentials">
+      <Version>1.5.3.2</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading">
       <Version>2.4.11.982</Version>
     </PackageReference>

--- a/ERP/app/ErpApp/ErpApp.iOS/ErpApp.iOS.csproj
+++ b/ERP/app/ErpApp/ErpApp.iOS/ErpApp.iOS.csproj
@@ -257,6 +257,9 @@
     <PackageReference Include="SkiaSharp.Views.Forms">
       <Version>1.68.0</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Essentials">
+      <Version>1.5.3.2</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading">
       <Version>2.4.11.982</Version>
     </PackageReference>

--- a/ERP/app/ErpApp/ErpApp/ErpApp.csproj
+++ b/ERP/app/ErpApp/ErpApp/ErpApp.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SkiaSharp" Version="1.68.0" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.0" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Xamarin.FFImageLoading" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.FFImageLoading.Transformations" Version="2.4.11.982" />

--- a/ERP/app/ErpApp/ErpApp/ViewModels/AboutPageViewModel.cs
+++ b/ERP/app/ErpApp/ErpApp/ViewModels/AboutPageViewModel.cs
@@ -30,7 +30,7 @@ namespace ErpApp.ViewModels
 
         private void OnLinkTapped(object obj)
         {
-            Device.OpenUri(new Uri(obj.ToString()));
+            Xamarin.Essentials.Launcher.OpenAsync(obj.ToString());
         }
     }
 }


### PR DESCRIPTION
#103 