### PR TITLE
Fix the ERP application in UWP.

### DIFF
--- a/ERP/app/ErpApp/ErpApp.UWP/App.xaml
+++ b/ERP/app/ErpApp/ErpApp.UWP/App.xaml
@@ -4,5 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:ErpApp.UWP"
     RequestedTheme="Light">
-
+    <local:UwpErpApp.Resources>
+        <SolidColorBrush x:Key="PivotHeaderItemSelectedPipeFill" Color="Transparent"/>
+    </local:UwpErpApp.Resources>
 </local:UwpErpApp>

--- a/ERP/app/ErpApp/ErpApp.UWP/App.xaml.cs
+++ b/ERP/app/ErpApp/ErpApp.UWP/App.xaml.cs
@@ -43,6 +43,7 @@ namespace ErpApp.UWP
             assemblies.Add(typeof(FFImageLoading.Forms.CachedImage).GetTypeInfo().Assembly);
             assemblies.Add(typeof(FFImageLoading.Forms.Platform.CachedImageRenderer).GetTypeInfo().Assembly);
             assemblies.Add(typeof(Xamarin.Forms.Image).GetTypeInfo().Assembly);
+            assemblies.Add(typeof(Xamarin.Forms.Platform.UWP.BoxViewBorderRenderer).GetTypeInfo().Assembly);
             assemblies.Add(typeof(Telerik.XamarinForms.Input.RadButton).GetTypeInfo().Assembly);
             assemblies.Add(typeof(Telerik.XamarinForms.InputRenderer.UWP.ButtonRenderer).GetTypeInfo().Assembly);
             assemblies.Add(typeof(Telerik.XamarinForms.Primitives.RadBorder).GetTypeInfo().Assembly);

--- a/ERP/app/ErpApp/ErpApp.UWP/App.xaml.cs
+++ b/ERP/app/ErpApp/ErpApp.UWP/App.xaml.cs
@@ -2,6 +2,8 @@
 using MvvmCross.Forms.Platforms.Uap.Views;
 using MvvmCross.Forms.Presenters;
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using Windows.ApplicationModel.Activation;
 
 namespace ErpApp.UWP
@@ -33,6 +35,20 @@ namespace ErpApp.UWP
         protected override IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
         {
             return new AppPagePresenter(viewPresenter);
+        }
+
+        public override IEnumerable<Assembly> GetViewAssemblies()
+        {
+            var assemblies = (List<Assembly>)base.GetViewAssemblies();
+            assemblies.Add(typeof(FFImageLoading.Forms.CachedImage).GetTypeInfo().Assembly);
+            assemblies.Add(typeof(FFImageLoading.Forms.Platform.CachedImageRenderer).GetTypeInfo().Assembly);
+            assemblies.Add(typeof(Xamarin.Forms.Image).GetTypeInfo().Assembly);
+            assemblies.Add(typeof(Telerik.XamarinForms.Input.RadButton).GetTypeInfo().Assembly);
+            assemblies.Add(typeof(Telerik.XamarinForms.InputRenderer.UWP.ButtonRenderer).GetTypeInfo().Assembly);
+            assemblies.Add(typeof(Telerik.XamarinForms.Primitives.RadBorder).GetTypeInfo().Assembly);
+            assemblies.Add(typeof(Telerik.XamarinForms.PrimitivesRenderer.UWP.BorderRenderer).GetTypeInfo().Assembly);
+
+            return assemblies;
         }
     }
 }

--- a/ERP/app/ErpApp/ErpApp.UWP/App.xaml.cs
+++ b/ERP/app/ErpApp/ErpApp.UWP/App.xaml.cs
@@ -40,10 +40,6 @@ namespace ErpApp.UWP
         public override IEnumerable<Assembly> GetViewAssemblies()
         {
             var assemblies = (List<Assembly>)base.GetViewAssemblies();
-            assemblies.Add(typeof(FFImageLoading.Forms.CachedImage).GetTypeInfo().Assembly);
-            assemblies.Add(typeof(FFImageLoading.Forms.Platform.CachedImageRenderer).GetTypeInfo().Assembly);
-            assemblies.Add(typeof(Xamarin.Forms.Image).GetTypeInfo().Assembly);
-            assemblies.Add(typeof(Xamarin.Forms.Platform.UWP.BoxViewBorderRenderer).GetTypeInfo().Assembly);
             assemblies.Add(typeof(Telerik.XamarinForms.Input.RadButton).GetTypeInfo().Assembly);
             assemblies.Add(typeof(Telerik.XamarinForms.InputRenderer.UWP.ButtonRenderer).GetTypeInfo().Assembly);
             assemblies.Add(typeof(Telerik.XamarinForms.Primitives.RadBorder).GetTypeInfo().Assembly);

--- a/ERP/app/ErpApp/ErpApp/Pages/Dashboard/PhoneView.xaml
+++ b/ERP/app/ErpApp/ErpApp/Pages/Dashboard/PhoneView.xaml
@@ -13,7 +13,7 @@
                             <Setter.Value>
                                 <ControlTemplate>
                                     <Grid>
-                                        <BoxView CornerRadius="4" BackgroundColor="White" />
+                                        <telerikBusyIndicator:RadBorder CornerRadius="4" BackgroundColor="White" />
                                         <ContentPresenter Margin="20" />
                                     </Grid>
                                 </ControlTemplate>

--- a/ERP/app/ErpApp/ErpApp/Pages/Dashboard/PhoneView.xaml
+++ b/ERP/app/ErpApp/ErpApp/Pages/Dashboard/PhoneView.xaml
@@ -2,7 +2,7 @@
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ErpApp.Pages.Dashboard.PhoneView"
-             xmlns:telerikBusyIndicator="clr-namespace:Telerik.XamarinForms.Primitives;assembly=Telerik.XamarinForms.Primitives"
+             xmlns:telerikPrimitives="clr-namespace:Telerik.XamarinForms.Primitives;assembly=Telerik.XamarinForms.Primitives"
              xmlns:cards="clr-namespace:ErpApp.Pages.Dashboard">
     <Grid>
         <ScrollView>
@@ -13,7 +13,7 @@
                             <Setter.Value>
                                 <ControlTemplate>
                                     <Grid>
-                                        <telerikBusyIndicator:RadBorder CornerRadius="4" BackgroundColor="White" />
+                                        <telerikPrimitives:RadBorder CornerRadius="4" BackgroundColor="White" />
                                         <ContentPresenter Margin="20" />
                                     </Grid>
                                 </ControlTemplate>
@@ -31,6 +31,6 @@
                 <cards:OrderStatusCard HeightRequest="200" Margin="0,0,0,10" Style="{StaticResource cardStyle}" />
             </StackLayout>
         </ScrollView>
-        <telerikBusyIndicator:RadBusyIndicator AnimationType="Animation3" IsBusy="{Binding IsBusy, Mode=TwoWay}" BackgroundColor="#E6FFFFFF" IsVisible="{Binding IsBusy}" AnimationContentColor="#2196F3" AnimationContentWidthRequest="60" AnimationContentHeightRequest="60"/>
+        <telerikPrimitives:RadBusyIndicator AnimationType="Animation3" IsBusy="{Binding IsBusy, Mode=TwoWay}" BackgroundColor="#E6FFFFFF" IsVisible="{Binding IsBusy}" AnimationContentColor="#2196F3" AnimationContentWidthRequest="60" AnimationContentHeightRequest="60"/>
     </Grid>
 </ContentView>

--- a/ERP/app/ErpApp/ErpApp/Pages/Dashboard/TabletView.xaml
+++ b/ERP/app/ErpApp/ErpApp/Pages/Dashboard/TabletView.xaml
@@ -12,7 +12,7 @@
                     <Setter.Value>
                         <ControlTemplate>
                             <Grid>
-                                <BoxView CornerRadius="4" BackgroundColor="White" />
+                                <telerikBusyIndicator:RadBorder CornerRadius="4" BackgroundColor="White" />
                                 <ContentPresenter Margin="20" />
                             </Grid>
                         </ControlTemplate>

--- a/ERP/app/ErpApp/ErpApp/Pages/Dashboard/TabletView.xaml
+++ b/ERP/app/ErpApp/ErpApp/Pages/Dashboard/TabletView.xaml
@@ -2,7 +2,7 @@
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:cards="clr-namespace:ErpApp.Pages.Dashboard"
-             xmlns:telerikBusyIndicator="clr-namespace:Telerik.XamarinForms.Primitives;assembly=Telerik.XamarinForms.Primitives"
+             xmlns:telerikPrimitives="clr-namespace:Telerik.XamarinForms.Primitives;assembly=Telerik.XamarinForms.Primitives"
              xmlns:app="clr-namespace:ErpApp"
              x:Class="ErpApp.Pages.Dashboard.TabletView">
     <Grid x:Name="LayoutRoot" Margin="10" RowSpacing="10" ColumnSpacing="10">
@@ -12,7 +12,7 @@
                     <Setter.Value>
                         <ControlTemplate>
                             <Grid>
-                                <telerikBusyIndicator:RadBorder CornerRadius="4" BackgroundColor="White" />
+                                <telerikPrimitives:RadBorder CornerRadius="4" BackgroundColor="White" />
                                 <ContentPresenter Margin="20" />
                             </Grid>
                         </ControlTemplate>
@@ -44,6 +44,6 @@
         <cards:NewCustomersCard Grid.Row="2" Grid.Column="0" Style="{StaticResource cardStyle}" />
         <cards:BestVendorsCard Grid.Row="2" Grid.Column="1" Style="{StaticResource cardStyle}" />
         <cards:OrderStatusCard Grid.Row="2" Grid.Column="2" Style="{StaticResource cardStyle}" />
-        <telerikBusyIndicator:RadBusyIndicator AnimationType="Animation3" Grid.ColumnSpan="3" Grid.RowSpan="3" IsBusy="{Binding IsBusy, Mode=TwoWay}"  BackgroundColor="#E6FFFFFF" IsVisible="{Binding IsBusy}" AnimationContentColor="#2196F3" AnimationContentWidthRequest="60" AnimationContentHeightRequest="60"/>
+        <telerikPrimitives:RadBusyIndicator AnimationType="Animation3" Grid.ColumnSpan="3" Grid.RowSpan="3" IsBusy="{Binding IsBusy, Mode=TwoWay}"  BackgroundColor="#E6FFFFFF" IsVisible="{Binding IsBusy}" AnimationContentColor="#2196F3" AnimationContentWidthRequest="60" AnimationContentHeightRequest="60"/>
     </Grid>
 </ContentView>

--- a/ERP/app/ErpApp/ErpApp/Pages/Products/ProductsTabletView.xaml
+++ b/ERP/app/ErpApp/ErpApp/Pages/Products/ProductsTabletView.xaml
@@ -239,8 +239,8 @@
                                         <Label Grid.Row="6" Grid.Column="0" Text="Color" TextColor="{StaticResource TitleLabelColor}" Margin="40,0,0,5"  FontSize="Small"/>
                                         <telerikPrimitives:RadPath Grid.Row="6" Grid.Column="1" WidthRequest="12" HeightRequest="12" HorizontalOptions="Start" VerticalOptions="Center" Geometry="{x:Static telerikInput:Geometries.Circle}" Fill="{Binding Path=Brush, Mode=OneWay}" Margin="{StaticResource itemSpacing}" />
 
-                                        <BoxView Grid.Row="6" Grid.ColumnSpan="2" HeightRequest="1" VerticalOptions="End" BackgroundColor="{StaticResource LineColor}" />
-                                        <BoxView Grid.RowSpan="7" Grid.Column="1" WidthRequest="1" HorizontalOptions="End" VerticalOptions="FillAndExpand" BackgroundColor="{StaticResource LineColor}" IsVisible="{Binding Index, Converter={StaticResource isEventCon}}" />
+                                        <telerikPrimitives:RadBorder Grid.Row="6" Grid.ColumnSpan="2" HeightRequest="1" VerticalOptions="End" BorderColor="{StaticResource LineColor}" />
+                                        <telerikPrimitives:RadBorder Grid.RowSpan="7" Grid.Column="1" WidthRequest="1" HorizontalOptions="End" VerticalOptions="FillAndExpand" BorderColor="{StaticResource LineColor}" IsVisible="{Binding Index, Converter={StaticResource isEventCon}}" />
                                     </Grid>
                                 </telerikListView:ListViewTemplateCell.View>
                             </telerikListView:ListViewTemplateCell>


### PR DESCRIPTION
- Replace BoxView in several places with RadBorder in order to prevent erroneous layout of the views using it. 
- Remove the underline of the selected tab. 
- Include the Input and Primivites binaries into the init method in order to prevent the linker from stripping their code.