### PR TITLE
Fix an exception when starting the ToDo app

### DIFF
--- a/ToDo/TodoApp/TodoApp/Controls/AppBar.xaml
+++ b/ToDo/TodoApp/TodoApp/Controls/AppBar.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <TemplatedView xmlns="http://xamarin.com/schemas/2014/forms" 
                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:xf="clr-namespace:Xamarin.Forms;assembly=Xamarin.Forms.Core"
                xmlns:converters="clr-namespace:TodoApp.Converters"
                xmlns:input="clr-namespace:Telerik.XamarinForms.Input;assembly=Telerik.XamarinForms.Input"
                x:Class="TodoApp.Controls.AppBar">
@@ -18,7 +19,7 @@
                 <On Platform="iOS">Black</On>
             </OnPlatform>
 
-            <OnPlatform x:Key="GridLayoutBounds" x:TypeArguments="Rectangle">
+            <OnPlatform x:Key="GridLayoutBounds" x:TypeArguments="xf:Rectangle">
                 <On Platform="Android">0, 0, 1, 56</On>
                 <On Platform="UWP">0, 0, 1, 48</On>
                 <On Platform="iOS">0, 0, 1, 44</On>


### PR DESCRIPTION
The exception was introduced after upgrading to Xamarin.Forms 4.8, which caused a name clash in XAML between Xamarin.Forms.Rectangle and Xamarin.Forms.Shapes.Rectangle.