### PR TITLE
Include an HttpClientHandler when creating the instance of MobileServiceClient

### DIFF
--- a/ArtGalleryCRM/ArtGalleryCRM.Forms/App.xaml.cs
+++ b/ArtGalleryCRM/ArtGalleryCRM.Forms/App.xaml.cs
@@ -29,28 +29,14 @@ namespace ArtGalleryCRM.Forms
             DependencyService.Register<AzureProductDataStore>();
             DependencyService.Register<AzureOrderDataStore>();
 
-            if (Device.RuntimePlatform == "Android")
+            MobileService = new MobileServiceClient(ServiceConstants.AzureMobileAppUrl, new HttpClientHandler())
             {
-                MobileService = new MobileServiceClient(ServiceConstants.AzureMobileAppUrl, new HttpClientHandler())
+                SerializerSettings = new MobileServiceJsonSerializerSettings
                 {
-                    SerializerSettings = new MobileServiceJsonSerializerSettings
-                    {
-                        CamelCasePropertyNames = true
-                    }
-                };
-            }
-            else
-            {
-                MobileService = new MobileServiceClient(ServiceConstants.AzureMobileAppUrl)
-                {
-                    SerializerSettings = new MobileServiceJsonSerializerSettings
-                    {
-                        CamelCasePropertyNames = true
-                    }
-                };
-            }
-            
-            
+                    CamelCasePropertyNames = true
+                }
+            };
+
             RootPage = new RootPage();
 
             Current.MainPage = RootPage;


### PR DESCRIPTION
Fix for There is an error when the app is oppened on iOS.
Add an System.Net.Http.HttpMessageHandler (HttpClientHandler specifically) when creating the instance of MobileServiceClient. This was done only for Android. https://stackoverflow.com/questions/61359772/microsoft-windowsazure-mobileservices-mobileserviceinvalidoperationexception-t 