### PR TITLE
Update deletion logic to use MvxRemovePresentationHint in order to wo…

### DIFF
--- a/ERP/app/ErpApp/ErpApp/ViewModels/SearchResultsViewModel.cs
+++ b/ERP/app/ErpApp/ErpApp/ViewModels/SearchResultsViewModel.cs
@@ -114,7 +114,7 @@ namespace ErpApp.ViewModels
 
         private async Task OnCancel()
         {
-            await this.navigationService.ChangePresentation(new MvvmCross.Presenters.Hints.MvxPopPresentationHint(this.senderType));
+            await this.navigationService.ChangePresentation(new MvvmCross.Presenters.Hints.MvxRemovePresentationHint(typeof(SearchResultsViewModel)));
         }
 
         private async Task OnSelect(object item)


### PR DESCRIPTION
…rkaround a bug in MvvmCross framework, where if a view is poped from the stack, it shows empty view on Android. Occurs when Search button is pressed and then back is pressed in Customers, Orders, Products and Vendors pages.
Same as: https://github.com/telerik/telerik-xamarin-forms-samples/pull/144