### PR TITLE
Update deletion logic to use MvxRemovePresentationHint in order to wo…

### DIFF
--- a/ERP/app/ErpApp/ErpApp/ViewModels/OrderCompletionViewModel.cs
+++ b/ERP/app/ErpApp/ErpApp/ViewModels/OrderCompletionViewModel.cs
@@ -49,13 +49,13 @@ namespace ErpApp.ViewModels
         private async Task OnCancel()
         {
             await this.navigationService.Close(this, new SigningResult(false));
-            await this.navigationService.ChangePresentation(new MvvmCross.Presenters.Hints.MvxPopPresentationHint(typeof(OrderScheduleViewModel)));
+            await this.navigationService.ChangePresentation(new MvvmCross.Presenters.Hints.MvxRemovePresentationHint(typeof(OrderCompletionViewModel)));
         }
 
         private async Task OnDone()
         {
             await this.navigationService.Close(this, new SigningResult(true));
-            await this.navigationService.ChangePresentation(new MvvmCross.Presenters.Hints.MvxPopPresentationHint(typeof(OrderScheduleViewModel)));
+            await this.navigationService.ChangePresentation(new MvvmCross.Presenters.Hints.MvxRemovePresentationHint(typeof(OrderCompletionViewModel)));
         }
 
         public class SigningResult


### PR DESCRIPTION
…rkaround a bug in MvvmCross framework, where if a view is poped from the stack, it shows empty view on Android. Occurs when Done or Back are pressed from OrderCompletion page.

Same as https://github.com/telerik/telerik-xamarin-forms-samples/pull/144